### PR TITLE
gbm: add gbm_bo_get_fd_for_plane

### DIFF
--- a/src/gbm/backends/dri/gbm_dri.c
+++ b/src/gbm/backends/dri/gbm_dri.c
@@ -802,6 +802,45 @@ gbm_dri_bo_get_handle_for_plane(struct gbm_bo *_bo, int plane)
    return ret;
 }
 
+static int
+gbm_dri_bo_get_plane_fd(struct gbm_bo *_bo, int plane)
+{
+   struct gbm_dri_device *dri = gbm_dri_device(_bo->gbm);
+   struct gbm_dri_bo *bo = gbm_dri_bo(_bo);
+   int fd = -1;
+
+   if (!dri->image || dri->image->base.version < 13 || !dri->image->fromPlanar) {
+      /* Preserve legacy behavior if plane is 0 */
+      if (plane == 0)
+         return gbm_dri_bo_get_fd(_bo);
+
+      errno = ENOSYS;
+      return -1;
+   }
+
+   /* dumb BOs can only utilize non-planar formats */
+   if (!bo->image) {
+      errno = EINVAL;
+      return -1;
+   }
+
+   if (plane >= get_number_planes(dri, bo->image)) {
+      errno = EINVAL;
+      return -1;
+   }
+
+   __DRIimage *image = dri->image->fromPlanar(bo->image, plane, NULL);
+   if (image) {
+      dri->image->queryImage(image, __DRI_IMAGE_ATTRIB_FD, &fd);
+      dri->image->destroyImage(image);
+   } else {
+      assert(plane == 0);
+      dri->image->queryImage(bo->image, __DRI_IMAGE_ATTRIB_FD, &fd);
+   }
+
+   return fd;
+}
+
 static uint32_t
 gbm_dri_bo_get_height(struct gbm_bo *_bo, int plane)
 {
@@ -1465,6 +1504,7 @@ dri_device_create(int fd)
    dri->base.bo_get_fd = gbm_dri_bo_get_fd;
    dri->base.bo_get_planes = gbm_dri_bo_get_planes;
    dri->base.bo_get_handle = gbm_dri_bo_get_handle_for_plane;
+   dri->base.bo_get_plane_fd = gbm_dri_bo_get_plane_fd;
    dri->base.bo_get_height = gbm_dri_bo_get_height;
    dri->base.bo_get_stride = gbm_dri_bo_get_stride;
    dri->base.bo_get_offset = gbm_dri_bo_get_offset;

--- a/src/gbm/gbm-symbols.txt
+++ b/src/gbm/gbm-symbols.txt
@@ -4,6 +4,7 @@ gbm_bo_destroy
 gbm_bo_get_bpp
 gbm_bo_get_device
 gbm_bo_get_fd
+gbm_bo_get_fd_for_plane
 gbm_bo_get_format
 gbm_bo_get_handle
 gbm_bo_get_handle_for_plane

--- a/src/gbm/main/gbm.c
+++ b/src/gbm/main/gbm.c
@@ -363,6 +363,26 @@ gbm_bo_get_handle_for_plane(struct gbm_bo *bo, int plane)
    return bo->gbm->bo_get_handle(bo, plane);
 }
 
+/** Get a DMA-BUF file descriptor for the specified plane of the buffer object
+ *
+ * This function creates a DMA-BUF (also known as PRIME) file descriptor
+ * handle for the specified plane of the buffer object.  Each call to
+ * gbm_bo_get_fd_for_plane() returns a new file descriptor and the caller is
+ * responsible for closing the file descriptor.
+
+ * \param bo The buffer object
+ * \param plane The plane to get a DMA-BUF for
+ * \return Returns a file descriptor referring to the underlying buffer or -1
+ * if an error occurs.
+ *
+ * \sa gbm_bo_get_fd()
+ */
+GBM_EXPORT int
+gbm_bo_get_fd_for_plane(struct gbm_bo *bo, int plane)
+{
+   return bo->gbm->bo_get_plane_fd(bo, plane);
+}
+
 /**
  * Get the chosen modifier for the buffer object
  *

--- a/src/gbm/main/gbm.h
+++ b/src/gbm/main/gbm.h
@@ -179,6 +179,7 @@ enum gbm_bo_format {
 #define GBM_FORMAT_NV16		__gbm_fourcc_code('N', 'V', '1', '6') /* 2x1 subsampled Cr:Cb plane */
 #define GBM_FORMAT_NV61		__gbm_fourcc_code('N', 'V', '6', '1') /* 2x1 subsampled Cb:Cr plane */
 
+#define GBM_FORMAT_P010         __gbm_fourcc_code('P', '0', '1', '0') /* 2x2 subsampled Cr:Cb plane */
 /*
  * 3 plane YCbCr
  * index 0: Y plane, [7:0] Y

--- a/src/gbm/main/gbm.h
+++ b/src/gbm/main/gbm.h
@@ -433,6 +433,9 @@ gbm_bo_get_plane_format_modifier(struct gbm_bo *bo, size_t plane);
 // (end) Neverware
 
 int
+gbm_bo_get_fd_for_plane(struct gbm_bo *bo, int plane);
+
+int
 gbm_bo_write(struct gbm_bo *bo, const void *buf, size_t count);
 
 void

--- a/src/gbm/main/gbmint.h
+++ b/src/gbm/main/gbmint.h
@@ -83,6 +83,7 @@ struct gbm_device {
    int (*bo_get_fd)(struct gbm_bo *bo);
    int (*bo_get_planes)(struct gbm_bo *bo);
    union gbm_bo_handle (*bo_get_handle)(struct gbm_bo *bo, int plane);
+   int (*bo_get_plane_fd)(struct gbm_bo *bo, int plane);
    uint32_t (*bo_get_height)(struct gbm_bo *bo, int plane);
    uint32_t (*bo_get_stride)(struct gbm_bo *bo, int plane);
    uint32_t (*bo_get_offset)(struct gbm_bo *bo, int plane);


### PR DESCRIPTION
This commit adds a new gbm_bo_get_fd_for_plane function, which does the
same as gbm_bo_get_fd but allows specifying the plane.

v2: - Rename to gbm_bo_get_fd_for_plane (Emil)

Signed-off-by: Simon Ser <contact@emersion.fr>
Signed-off-by: Tomeu Vizoso <tomeu.vizoso@collabora.com>
Reviewed-by: Daniel Stone <daniels@collabora.com>
Part-of: <https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/5442>
(cherry picked from commit e10a094e0ab96699b9be81d2f5afea5eaa71338b)

Required as drm-tests uses this in d91.
I have not tested it but assume it will fix the issues seen here: https://neverware-coracle.s3.amazonaws.com/logs/worker/H80K3buy-BuildModifiedPackages.log